### PR TITLE
Correct license information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "cobiro/wiremock",
   "type": "project",
   "description": "Wiremock library for easier integration with PHPUnit.",
-  "license": "proprietary",
+  "license": "MIT",
   "require": {
     "php": "^8.1",
     "phpunit/phpunit": "^10.0",


### PR DESCRIPTION
Based on https://github.com/Cobiro/wiremock-phpunit/blob/2.1.2/LICENSE this lib is licensed under MIT and not a proprietary package.